### PR TITLE
ci: golangci-lint v2 and groot family map

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 
 ## How to test
 
-- [ ] `make lint-fix` then `make ci` (or `make all` for coverage + complexity)
+- [ ] `make lint-fix` then `make ci` (fmt-check + golangci-lint + gocyclo + tests; or `make all` for coverage too)
 - [ ] `make security` (if your change touches deps, Docker, or security-sensitive paths)
 - [ ] Manual verification (if applicable)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   lint:
-    name: gofmt + go vet + gocyclo
+    name: gofmt + golangci-lint + gocyclo
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -38,8 +38,11 @@ jobs:
             exit 1
           fi
 
-      - name: go vet
-        run: make lint
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.5.0
+          args: ./...
 
       - name: Cyclomatic complexity (gocyclo)
         run: make gocyclo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.5.0
+          # Keep in sync with GOLANGCI_LINT_VERSION in GNUmakefile (≥ v2.9.0 for Go 1.26).
+          version: v2.12.2
           args: ./...
 
       - name: Cyclomatic complexity (gocyclo)

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 !.gitignore
 !.dockerignore
 !.goreleaser.yaml
+!.golangci.yml
 !.github/
 !.github/**
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,62 @@
+# Conservative golangci-lint v2 config for groot (audit M2).
+# Keep noise low: correctness + a few style checks. Complexity stays in `make gocyclo`.
+# Docs: https://golangci-lint.run/docs/configuration/file/
+version: "2"
+
+run:
+  timeout: 5m
+  tests: true
+
+linters:
+  default: none
+  enable:
+    - govet
+    - staticcheck
+    - ineffassign
+    - misspell
+    - revive
+    - unused
+  settings:
+    misspell:
+      locale: US
+    revive:
+      # Minimal set — expand later if clean.
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+          disabled: true # handler tables use (r, ctx, args); reorder is M3/k8srunner debt
+        - name: context-keys-type
+        - name: dot-imports
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: exported
+          disabled: true # noisy for internal/ until API docs catch up
+        - name: if-return
+        - name: increment-decrement
+        - name: var-declaration
+        - name: package-comments
+          disabled: true
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+          disabled: true # internal helpers intentionally return unexported types
+        - name: indent-error-flow
+        - name: errorf
+        - name: empty-block
+        - name: superfluous-else
+        - name: unused-parameter
+          disabled: true
+        - name: unreachable-code
+        - name: redefines-builtin-id
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 10

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -2,7 +2,7 @@
 
 ## What This Is
 
-GROOT is a **read-only Kubernetes log and context collector CLI** (Go). One `groot collect` produces a timestamped `.tar.gz` with pod logs, events, API snapshots, RCA TSVs, and `extras/manifest.json` for incident response, tickets, and postmortems. Companion deploy lives in **groot-selfhosted**; team inbox/web is planned as **groot-share** (separate repo). Not a live log agent, not a public Go SDK (`internal/` since 1.0.0).
+GROOT is a **read-only Kubernetes log and context collector CLI** (Go). One `groot collect` produces a timestamped `.tar.gz` with pod logs, events, API snapshots, RCA TSVs, and `extras/manifest.json` for incident response, tickets, and postmortems. Companion deploy lives in **groot-selfhosted**; on-demand collect in **groot-trigger**; VPS archive door in **groot-share** (**gfs**), deployed via **groot-share-selfhosted**. Not a live log agent, not a public Go SDK (`internal/` since 1.0.0).
 
 ## Core Value
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -6,9 +6,9 @@ current_phase: —
 current_phase_name: —
 status: Milestone v1.1.1 SHIPPED — tag on main; next Band 4 backlog
 stopped_at: v1.1.1 tagged on main (549f78c); develop at 549f78c
-last_updated: "2026-08-12T14:04:00Z"
-last_activity: 2026-08-12
-last_activity_desc: Status sync — align STATE with v1.1.1 / HEAD 549f78c after Hermes audit review
+last_updated: "2026-08-14T02:54:00Z"
+last_activity: 2026-08-13
+last_activity_desc: Docs — README/SPEC/AGENTS/ROADMAP link groot family (selfhosted, trigger, share/gfs, share-selfhosted)
 progress:
   total_phases: 4
   completed_phases: 4

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,14 +1,14 @@
 ---
 gsd_state_version: 1.0
-milestone: v1.1.0
+milestone: v1.1.1
 milestone_name: milestone
 current_phase: —
 current_phase_name: —
-status: Milestone v1.1.0 SHIPPED — tag on main; next Band 4 backlog
-stopped_at: v1.1.0 tagged on main (0a23c6e); develop at 7be4ab4
-last_updated: "2026-08-11T13:50:00Z"
-last_activity: 2026-08-11
-last_activity_desc: Status sync morning-after — Phase 4 + release confirmed shipped overnight
+status: Milestone v1.1.1 SHIPPED — tag on main; next Band 4 backlog
+stopped_at: v1.1.1 tagged on main (549f78c); develop at 549f78c
+last_updated: "2026-08-12T14:04:00Z"
+last_activity: 2026-08-12
+last_activity_desc: Status sync — align STATE with v1.1.1 / HEAD 549f78c after Hermes audit review
 progress:
   total_phases: 4
   completed_phases: 4
@@ -24,26 +24,26 @@ progress:
 See: .planning/PROJECT.md (updated 2026-08-10)
 
 **Core value:** Ticket-ready evidence archive — freeze cluster state into one reproducible bundle operators can attach, inspect offline, and summarize for RCA / LLM paste.
-**Current focus:** Milestone **v1.1.0 (`#69`)** shipped — next product picks from Band 4 backlog (`#32`, `#56`, …)
+**Current focus:** Milestone **v1.1.1** shipped (patch on `#69` line) — next product picks from Band 4 backlog (`#32`, `#56`, `#67` 429 backoff, …)
 
 ## Current Position
 
-Milestone: **v1.1.0 SHIPPED**
-- Tag: `v1.1.0` → `main` @ `0a23c6e` (merge + GNUmakefile hotfix)
-- `develop` @ `7be4ab4` (synced with `origin/develop`)
-- `VERSION` = **1.1.0**
-- GSD phases 1–4 complete (QUAL-01…04 closed)
+Milestone: **v1.1.1 SHIPPED**
+- Tag: `v1.1.1` → `main` @ `549f78c` (Merge PR #3)
+- `develop` @ `549f78c` (synced with `origin/develop`)
+- `VERSION` = **1.1.1**
+- GSD phases 1–4 (v1.1.0 `#69`) remain complete; v1.1.1 is a patch release (path expansion, concurrent-safe `sessionBase`, S3 credential trim)
 
-Status: Overnight work closed Phase 4 (fixtures, goldens, SPEC, plan-1.1.0, CHANGELOG) + release hygiene; human merge/tag done.
-Last activity: 2026-08-11 — morning status sync
+Status: v1.1.0 analyze/LLM milestone closed; v1.1.1 patch tagged and pushed.
+Last activity: 2026-08-12 — STATE sync after independent Hermes/MiniMax-M3 audit review
 
-Progress: [████████████████████] 100% (milestone)
+Progress: [████████████████████] 100% (v1.1.0 milestone; patch v1.1.1 shipped)
 
 ## Performance Metrics
 
 **Velocity:**
 
-- Total plans completed: 8 (P1×2 + P2×2 + P3×1 + P4×3)
+- Total plans completed: 8 (P1×2 + P2×2 + P3×1 + P4×3) for v1.1.0
 - Average duration: —
 - Total execution time: —
 
@@ -54,7 +54,7 @@ Progress: [████████████████████] 100% (m
 | 1 Shared Offline Archive Reader | 2/2 | Complete |
 | 2 Heuristic Analyze + Executive Markdown | 2/2 | Complete (verified) |
 | 3 LLM-Ready Markdown Packaging | 1/1 | Complete (verified) |
-| 4 Fixtures, SPEC, and Release Lock | 3/3 | Complete — shipped |
+| 4 Fixtures, SPEC, and Release Lock | 3/3 | Complete — shipped (v1.1.0); patch v1.1.1 follow-up |
 
 ## Decisions
 
@@ -62,10 +62,10 @@ See phase CONTEXT files. Caps locked in SPEC: arcread decompress **16 GiB**, ana
 
 ## Blockers / Notes
 
-- None for v1.1.0.
-- Untracked local noise: `.planning/.../start-epoch`, research `.cache/` — not part of ship.
-- Product `ROADMAP.md` “Current focus” still listed `#69` as Next until status sync commit.
+- None for v1.1.1.
+- Hermes audit 2026-08-12 (`.no-va-al-repo/`) — useful backlog: golangci bootstrap, SECURITY.md threat model; ignore L1 binary-size myth; W2/COVER_MIN claim was wrong (gate enforces).
+- Local noise under `.planning/` research cache — gitignored.
 
 ## Next
 
-Pick next Band 4 item (candidates: `#32` multi-cluster, `#56` diff, `#43` context). Or dogfood / GH Release notes if not yet published on GitHub Releases UI.
+Pick next Band 4 item (candidates: `#32` multi-cluster, `#56` diff, `#67` dynamic API rate limiting / 429 backoff, `#43` context). Optional hygiene: `.golangci.yml`, expand SECURITY.md threat model.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -6,9 +6,9 @@ current_phase: —
 current_phase_name: —
 status: Milestone v1.1.1 SHIPPED — tag on main; next Band 4 backlog
 stopped_at: v1.1.1 tagged on main (549f78c); develop at 549f78c
-last_updated: "2026-08-14T02:54:00Z"
+last_updated: "2026-08-14T03:16:00Z"
 last_activity: 2026-08-13
-last_activity_desc: Docs — README/SPEC/AGENTS/ROADMAP link groot family (selfhosted, trigger, share/gfs, share-selfhosted)
+last_activity_desc: Security — bump Go 1.26.5 → 1.26.6 (govulncheck stdlib CVEs); golangci-lint v2.12.2 on develop/PR #4
 progress:
   total_phases: 4
   completed_phases: 4

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -10,7 +10,7 @@ analysis_date: 2026-08-10
 ## Languages
 
 **Primary:**
-- Go 1.26.5 - All application code (`cmd/`, `internal/`); module `github.com/hrodrig/groot` in `go.mod`
+- Go 1.26.6 - All application code (`cmd/`, `internal/`); module `github.com/hrodrig/groot` in `go.mod`
 
 **Secondary:**
 - YAML - Operator config (`configs/groot.yml.sample`, `examples/`)
@@ -21,7 +21,7 @@ analysis_date: 2026-08-10
 ## Runtime
 
 **Environment:**
-- Go toolchain 1.26.5 (pinned in `go.mod`; Docker builder `golang:1.26.5-alpine`)
+- Go toolchain 1.26.6 (pinned in `go.mod`; Docker builder `golang:1.26.6-alpine`)
 - CGO disabled for release binaries (`CGO_ENABLED=0` in `.goreleaser.yaml` and `Dockerfile`)
 - No Node/Python/browser runtime — pure CLI process
 
@@ -84,7 +84,7 @@ analysis_date: 2026-08-10
 ## Platform Requirements
 
 **Development:**
-- Go 1.26.5+ matching `go.mod`
+- Go 1.26.6+ matching `go.mod`
 - Optional: Docker/buildx, kind + kubectl for E2E (`make test-e2e-kind`)
 - Optional: `bc` when enforcing `COVER_MIN` > 0; goreleaser for `make snapshot` / `release-check`
 - Any OS with a Go toolchain; releases also target FreeBSD/OpenBSD via contrib ports

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -12,7 +12,7 @@ analysis_date: 2026-08-10
 **Runner:**
 - Go `testing` package (stdlib)
 - Config: Makefile targets (`test`, `cover`, `ci`, `release-check`); CI in `.github/workflows/ci.yml`
-- Go version from `go.mod` (`go 1.26.5`) via `actions/setup-go` `go-version-file`
+- Go version from `go.mod` (`go 1.26.6`) via `actions/setup-go` `go-version-file`
 
 **Assertion Library:**
 - Stdlib only (`t.Fatal`, `t.Fatalf`, `t.Errorf`, `t.Error`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,15 +6,19 @@ This repository is the **GROOT product**: CLI, collector engine, behavior contra
 |------|------|
 | **groot** (this repo) | `groot collect`, SPEC, ROADMAP, CHANGELOG, GoReleaser, `ghcr.io/hrodrig/groot` |
 | **[groot-selfhosted](https://github.com/hrodrig/groot-selfhosted)** | Operator deployment: Docker/Podman, Helm CronJob, flat manifests, cron/systemd |
+| **[groot-trigger](https://github.com/hrodrig/groot-trigger)** | In-cluster HTTP → Job `groot collect` (on-demand; not a long-lived HTTP server in this CLI) |
+| **[groot-share](https://github.com/hrodrig/groot-share)** (**gfs**) | VPS web/API door for `.tar.gz` archives: auth, ingest, list, download, audit, retention |
+| **[groot-share-selfhosted](https://github.com/hrodrig/groot-share-selfhosted)** | Operator deploy for **gfs**: Compose, systemd, Helm (`vps` / `vps-s3`) |
 
 ## Scope
 
 - **`cmd/`**, **`internal/`**, **`docs/SPECIFICATIONS.md`**, **`configs/groot.yml.sample`**, **`contrib/`** (packaging), **`testing/`** (product E2E).
 - Do **not** add Helm charts, bastion runbooks, or cron wrappers here — those belong in **groot-selfhosted**.
+- Do **not** add on-demand HTTP or gfs (archive catalog / VPS door) here — those belong in **groot-trigger**, **groot-share**, and **groot-share-selfhosted**.
 
 ## Operator deployment
 
-For Helm, in-cluster CronJob, `docker run` with kubeconfig, and standalone scheduling, link to **[groot-selfhosted](https://github.com/hrodrig/groot-selfhosted)** (`run/README.md`).
+For Helm, in-cluster CronJob, `docker run` with kubeconfig, and standalone scheduling, link to **[groot-selfhosted](https://github.com/hrodrig/groot-selfhosted)** (`run/README.md`). On-demand collect: **[groot-trigger](https://github.com/hrodrig/groot-trigger)**. VPS archive door: **[groot-share](https://github.com/hrodrig/groot-share)**; gfs deploy: **[groot-share-selfhosted](https://github.com/hrodrig/groot-share-selfhosted)**.
 
 ## Language
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Go 1.26.5 → 1.26.6** in `go.mod` and **`Dockerfile`** builder image (stdlib CVEs cleared by govulncheck): **GO-2026-6087** (`net/url`), **GO-2026-6091** (`html/template`), **GO-2026-6090** (`crypto/tls`), **GO-2026-6089** / **GO-2026-5026** (`net/http`), **GO-2026-6088** (`encoding/xml`), **GO-2026-5972** (`encoding/asn1`).
+
 ### Changed
 
-- **CI / lint:** `make lint` and the GitHub Actions lint job now run **golangci-lint** v2 (`.golangci.yml`: govet, staticcheck, ineffassign, misspell, revive, unused) instead of bare `go vet`. Cyclomatic complexity remains a separate `make gocyclo` gate. Pin bumped to **v2.12.2** (Go **1.26**-built binary; v2.5.0 failed CI with exit 3 against `go 1.26.5`).
+- **CI / lint:** `make lint` and the GitHub Actions lint job now run **golangci-lint** v2 (`.golangci.yml`: govet, staticcheck, ineffassign, misspell, revive, unused) instead of bare `go vet`. Cyclomatic complexity remains a separate `make gocyclo` gate. Pin bumped to **v2.12.2** (Go **1.26**-built binary; v2.5.0 failed CI with exit 3 against older `go 1.26.5`).
+- **README:** Go version badge synced to **1.26.6**.
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **CI / lint:** `make lint` and the GitHub Actions lint job now run **golangci-lint** v2 (`.golangci.yml`: govet, staticcheck, ineffassign, misspell, revive, unused) instead of bare `go vet`. Cyclomatic complexity remains a separate `make gocyclo` gate.
 
+### Docs
+
+- **Groot family:** README, SPEC, and AGENTS now point at companion repos **[groot-selfhosted](https://github.com/hrodrig/groot-selfhosted)**, **[groot-trigger](https://github.com/hrodrig/groot-trigger)**, **[groot-share](https://github.com/hrodrig/groot-share)** (**gfs**), and **[groot-share-selfhosted](https://github.com/hrodrig/groot-share-selfhosted)**.
+
 ## [1.1.1] - 2026-08-11
 
 Patch — path expansion, concurrent-safe capture naming, S3 credential trim.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **CI / lint:** `make lint` and the GitHub Actions lint job now run **golangci-lint** v2 (`.golangci.yml`: govet, staticcheck, ineffassign, misspell, revive, unused) instead of bare `go vet`. Cyclomatic complexity remains a separate `make gocyclo` gate.
+- **CI / lint:** `make lint` and the GitHub Actions lint job now run **golangci-lint** v2 (`.golangci.yml`: govet, staticcheck, ineffassign, misspell, revive, unused) instead of bare `go vet`. Cyclomatic complexity remains a separate `make gocyclo` gate. Pin bumped to **v2.12.2** (Go **1.26**-built binary; v2.5.0 failed CI with exit 3 against `go 1.26.5`).
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CI / lint:** `make lint` and the GitHub Actions lint job now run **golangci-lint** v2 (`.golangci.yml`: govet, staticcheck, ineffassign, misspell, revive, unused) instead of bare `go vet`. Cyclomatic complexity remains a separate `make gocyclo` gate.
+
 ## [1.1.1] - 2026-08-11
 
 Patch — path expansion, concurrent-safe capture naming, S3 credential trim.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ On release: move `[Unreleased]` to a version section, add a **Shipped** row in R
 ## Before you open a PR
 
 1. **Format:** `make lint-fix` (applies `gofmt -s` across the tree).
-2. **Verify:** `make ci` runs **`fmt-check`** (same `gofmt -s` gate as CI), **`go vet`**, **`gocyclo`**, and **`go test -race`** — it matches the GitHub Actions **lint** and **test** jobs.
+2. **Verify:** `make ci` runs **`fmt-check`** (same `gofmt -s` gate as CI), **`golangci-lint`** (`.golangci.yml`), **`gocyclo`**, and **`go test -race`** — it matches the GitHub Actions **lint** and **test** jobs.
 3. **Broader check (optional):** `make all` adds merged coverage and a build; maintainers run **`make release-check`** before tagging a release (GoReleaser config, **`fmt-check`**, **`lint`**, **`cover`** with `COVER_MIN`, **`security`**, and optionally **`STRICT_RELEASE=1`** for **`docker-scan`**).
 
 Keep commits scoped and messages understandable.

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Release images: GoReleaser builds static binaries, then Dockerfile.release packages them.
 # Multi-arch: docker buildx build --platform linux/amd64,linux/arm64 -t groot:local .
 # Makefile passes APP_VERSION, GIT_COMMIT, GIT_BRANCH, BUILD_DATE from VERSION, git, and date.
-FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine AS builder
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN go mod download

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -26,6 +26,9 @@ check-docker = @docker info >/dev/null 2>&1 || { echo "Error: Docker is not runn
 GRYPE_FAIL_ON ?= high
 GRYPE_DIR_EXCLUDES := --exclude './bin/**' --exclude './work/**' --exclude './dist/**'
 
+# Pin golangci-lint for reproducible `make lint` / CI (config is v2).
+GOLANGCI_LINT_VERSION ?= v2.5.0
+
 # Release: optional strict image scan (see release-check).
 STRICT_RELEASE ?= 0
 
@@ -94,7 +97,7 @@ help:
 	@echo "  $(GREEN)fmt$(RESET)                      gofmt -w . (no simplify; use lint-fix for gofmt -s)"
 	@echo "  $(GREEN)fmt-check$(RESET)                Fail if gofmt -s would change any file (same as CI)"
 	@echo "  $(GREEN)lint-fix$(RESET)                 gofmt -s -w ."
-	@echo "  $(GREEN)lint$(RESET)                     Run go vet"
+	@echo "  $(GREEN)lint$(RESET)                     golangci-lint run (govet/staticcheck/…; pin GOLANGCI_LINT_VERSION=$(GOLANGCI_LINT_VERSION))"
 	@echo "  $(GREEN)vet$(RESET)                      go vet ./..."
 	@echo "  $(GREEN)gocyclo$(RESET)                  Fail if any function has cyclomatic complexity >= 15"
 	@echo "  $(GREEN)govulncheck$(RESET)              govulncheck via go run (no install)"
@@ -108,7 +111,7 @@ help:
 	@echo "  $(GREEN)scan$(RESET)                     Build amd64/arm64 images and scan both with Grype"
 	@echo ""
 	@echo "$(YELLOW)Release:$(RESET)"
-	@echo "  $(GREEN)release-check$(RESET)            VERSION semver + goreleaser + fmt-check + vet + cover + security"
+	@echo "  $(GREEN)release-check$(RESET)            VERSION semver + goreleaser + fmt-check + golangci-lint + cover + security"
 	@echo "  $(GREEN)snapshot$(RESET)                 Goreleaser snapshot to $(DIST)/ (no tag)"
 	@echo "  $(GREEN)dist-freebsd$(RESET)             Tarball for FreeBSD ports (default FREEBSD_ARCH=$(FREEBSD_ARCH))"
 	@echo "  $(GREEN)dist-openbsd$(RESET)             Tarball for OpenBSD ports (default OPENBSD_ARCH=$(OPENBSD_ARCH))"
@@ -170,8 +173,13 @@ fmt-check:
 		exit 1; \
 	fi
 
+# golangci-lint v2 (.golangci.yml). Prefer binary on PATH; else go run pinned module.
 lint:
-	go vet ./...
+	@if command -v golangci-lint >/dev/null 2>&1; then \
+		golangci-lint run ./...; \
+	else \
+		go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run ./...; \
+	fi
 
 vet:
 	go vet ./...
@@ -241,7 +249,7 @@ govulncheck:
 vulncheck: govulncheck
 
 ci: fmt-check lint gocyclo test
-	@echo "OK: ci (fmt-check, vet, gocyclo, test)"
+	@echo "OK: ci (fmt-check, golangci-lint, gocyclo, test)"
 
 gocyclo:
 	go run github.com/fzipp/gocyclo/cmd/gocyclo@latest -over 14 .
@@ -269,7 +277,7 @@ test-e2e-kind: build
 
 e2e-kind: test-e2e-kind
 
-# Semver + goreleaser + fmt-check (CI parity) + vet + cover + security (+ optional docker-scan when STRICT_RELEASE=1).
+# Semver + goreleaser + fmt-check (CI parity) + golangci-lint + cover + security (+ optional docker-scan when STRICT_RELEASE=1).
 release-check:
 	@test -f VERSION || { echo "VERSION file is required"; exit 1; }
 	@echo "Release version: $(VERSION) (tag: $(TAG))"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -27,7 +27,9 @@ GRYPE_FAIL_ON ?= high
 GRYPE_DIR_EXCLUDES := --exclude './bin/**' --exclude './work/**' --exclude './dist/**'
 
 # Pin golangci-lint for reproducible `make lint` / CI (config is v2).
-GOLANGCI_LINT_VERSION ?= v2.5.0
+# Must be ≥ v2.9.0 so the published binary is built with Go ≥ 1.26 (matches go.mod).
+# Family pin: groot-trigger / groot-share use v2.12.2.
+GOLANGCI_LINT_VERSION ?= v2.12.2
 
 # Release: optional strict image scan (see release-check).
 STRICT_RELEASE ?= 0

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Release](https://img.shields.io/github/v/release/hrodrig/groot?display_name=tag&label=release&logo=github)](https://github.com/hrodrig/groot/releases)
 [![Version](https://img.shields.io/badge/version-1.1.1-blue)](https://github.com/hrodrig/groot/releases)
-[![Go](https://img.shields.io/badge/Go-1.26.5-00ADD8?logo=go)](https://go.dev/)
+[![Go](https://img.shields.io/badge/Go-1.26.6-00ADD8?logo=go)](https://go.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![pkg.go.dev](https://pkg.go.dev/badge/github.com/hrodrig/groot)](https://pkg.go.dev/github.com/hrodrig/groot)
 [![CI](https://github.com/hrodrig/groot/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/hrodrig/groot/actions/workflows/ci.yml)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![Article on DEV](https://img.shields.io/badge/dev.to-article-0A0A0A?logo=devdotto&logoColor=white)](https://dev.to/hrodrig/groot-one-archive-for-cluster-diagnostics-2d76)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/hrodrig/groot/)
 
-**Repo:** [github.com/hrodrig/groot](https://github.com/hrodrig/groot) · **Releases:** [GitHub Releases](https://github.com/hrodrig/groot/releases) · **Spec:** [SPECIFICATIONS.md](SPECIFICATIONS.md) · **Operator:** [groot-selfhosted](https://github.com/hrodrig/groot-selfhosted) · **Changelog:** [CHANGELOG.md](CHANGELOG.md) · **Roadmap:** [ROADMAP.md](ROADMAP.md) · **Article:** [GROOT on DEV — one archive for cluster diagnostics](https://dev.to/hrodrig/groot-one-archive-for-cluster-diagnostics-2d76)
+**Repo:** [github.com/hrodrig/groot](https://github.com/hrodrig/groot) · **Releases:** [GitHub Releases](https://github.com/hrodrig/groot/releases) · **Spec:** [SPECIFICATIONS.md](SPECIFICATIONS.md) · **Operator:** [groot-selfhosted](https://github.com/hrodrig/groot-selfhosted) · **On-demand:** [groot-trigger](https://github.com/hrodrig/groot-trigger) · **Share (gfs):** [groot-share](https://github.com/hrodrig/groot-share) · **Share deploy:** [groot-share-selfhosted](https://github.com/hrodrig/groot-share-selfhosted) · **Changelog:** [CHANGELOG.md](CHANGELOG.md) · **Roadmap:** [ROADMAP.md](ROADMAP.md) · **Article:** [GROOT on DEV — one archive for cluster diagnostics](https://dev.to/hrodrig/groot-one-archive-for-cluster-diagnostics-2d76)
 
 <p align="center">
   <img src="docs/assets/groot-readme-hero.png" alt="GROOT — Kubernetes log collector CLI · v1.0 stable contract" width="100%" />
@@ -31,7 +31,19 @@ GROOT is a **read-only Kubernetes log and context collector**: a single **`groot
 
 That workflow supports **incident response**, **troubleshooting**, and **root cause analysis (RCA)**: one reproducible bundle replaces scattered `kubectl` copy-paste, so you can reconstruct *what the cluster looked like* when you ran collect and shorten postmortems.
 
-> **Operator deployment** (bastion, cron, `docker run`, Helm CronJob, flat manifests): **[groot-selfhosted](https://github.com/hrodrig/groot-selfhosted)** — this repo ships the CLI binary, packages, and container image only.
+> **Operator deployment** (bastion, cron, `docker run`, Helm CronJob, flat manifests): **[groot-selfhosted](https://github.com/hrodrig/groot-selfhosted)** — this repo ships the CLI binary, packages, and container image only. On-demand in-cluster collect: **[groot-trigger](https://github.com/hrodrig/groot-trigger)**. Archive catalog on a VPS: **[groot-share](https://github.com/hrodrig/groot-share)** (**gfs**); deploy playbooks: **[groot-share-selfhosted](https://github.com/hrodrig/groot-share-selfhosted)**.
+
+<a id="groot-family"></a>
+
+**Groot family** (companion repos — collect stays in this CLI):
+
+| Repo | Role |
+|------|------|
+| **groot** (this repo) | CLI: `collect` / validate / inspect / analyze → `.tar.gz`; optional `upload.s3` / `upload.gcs` / `upload.sftp` |
+| **[groot-selfhosted](https://github.com/hrodrig/groot-selfhosted)** | Operator deploy for **groot**: CronJob, bastion, Helm; S3-only and SFTP-VPS playbooks |
+| **[groot-trigger](https://github.com/hrodrig/groot-trigger)** | In-cluster HTTP → Job `groot collect`; fire-and-forget; optional post-collect upload |
+| **[groot-share](https://github.com/hrodrig/groot-share)** (**gfs**) | VPS web + API: auth, HTTP ingest, list, download, audit, retention (`vps` and `vps-s3`) |
+| **[groot-share-selfhosted](https://github.com/hrodrig/groot-share-selfhosted)** | Operator deploy for **gfs**: VPS, `vps-s3`, systemd, Docker, Helm |
 
 **Related tools (same maintainer):**
 - **[pgwd](https://github.com/hrodrig/pgwd)** — PostgreSQL connection watchdog ([live traffic](https://gghstats.hermesrodriguez.com/hrodrig/pgwd); deploy: [pgwd-selfhosted](https://github.com/hrodrig/pgwd-selfhosted))
@@ -44,6 +56,7 @@ That workflow supports **incident response**, **troubleshooting**, and **root ca
 - [README badge reference](docs/badges.md)
 - [Specifications (behavior contract)](SPECIFICATIONS.md)
 - [Roadmap (planned work)](docs/ROADMAP.md)
+- [Groot family](#groot-family)
 - [Features](#features)
 - [Requirements](#requirements)
 - [Install or update](#install-or-update)
@@ -941,14 +954,16 @@ This repository ships the **CLI**, **packages**, and **`ghcr.io/hrodrig/groot`**
 | Helm CronJob (in-cluster) | [run/deploy/](https://github.com/hrodrig/groot-selfhosted/tree/main/run/deploy) · **`helm repo add groot https://hrodrig.github.io/groot-selfhosted`** |
 | Flat CronJob YAML | [run/deploy/k8s/cronjob.yaml](https://github.com/hrodrig/groot-selfhosted/blob/main/run/deploy/k8s/cronjob.yaml) |
 | cron / systemd (Releases binary) | [run/standalone/](https://github.com/hrodrig/groot-selfhosted/tree/main/run/standalone) |
+| On-demand collect (HTTP → Job) | **[groot-trigger](https://github.com/hrodrig/groot-trigger)** |
+| Archive catalog on a VPS (**gfs**) | **[groot-share](https://github.com/hrodrig/groot-share)** — deploy: **[groot-share-selfhosted](https://github.com/hrodrig/groot-share-selfhosted)** |
 
-Pull the image from here (pin to the [version badge](#readme-top) — currently **`1.0.6`**):
+Pull the image from here (pin to the [version badge](#readme-top) — currently **`v1.1.1`**):
 
 ```bash
-docker pull ghcr.io/hrodrig/groot:1.0.6
+docker pull ghcr.io/hrodrig/groot:v1.1.1
 ```
 
-In-cluster behavior (CronJob, RBAC, `/out` volume) is documented in [SPEC §8](SPECIFICATIONS.md#8-runtime-and-kubernetes-access).
+In-cluster behavior (CronJob, RBAC, `/out` volume) is documented in [SPEC §8](SPECIFICATIONS.md#8-runtime-and-kubernetes-access). See [Groot family](#groot-family) for the full companion map.
 
 [↑ Back to top](#readme-top)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,7 +47,7 @@ Ship lock for analyze: **[`docs/plan-1.1.0.md`](docs/plan-1.1.0.md)**.
 
 GROOT is a **read-only log and context collector**: one **`groot collect`** produces a **timestamped `.tar.gz`** for incident response and RCA. The runtime path is **client-go** end-to-end (no `kubectl` binary). Configuration is **YAML + env**; optional **notify** fan-out fires after a **successful** collect and, when configured, on **abort** or **partial job failure** (#19).
 
-**Product positioning:** groot = **ticket-ready bundle** (`.tar.gz` + manifest + RCA TSVs + notify/upload). Tools like [kubectl-gather](https://github.com/nirs/kubectl-gather) optimize for **multi-cluster YAML trees and manual diff** — complementary, not identical (#60).
+**Product positioning:** groot = **ticket-ready bundle** (`.tar.gz` + manifest + RCA TSVs + notify/upload). Scheduled / bastion runbooks: **[groot-selfhosted](https://github.com/hrodrig/groot-selfhosted)**. On-demand in-cluster collect: **[groot-trigger](https://github.com/hrodrig/groot-trigger)**. VPS archive catalog: **[groot-share](https://github.com/hrodrig/groot-share)** (**gfs**); deploy: **[groot-share-selfhosted](https://github.com/hrodrig/groot-share-selfhosted)**. Tools like [kubectl-gather](https://github.com/nirs/kubectl-gather) optimize for **multi-cluster YAML trees and manual diff** — complementary, not identical (#60).
 
 **Target architecture:** **0.9.x** shipped operator wins. **1.0.0** froze **config + archive layout** and moved code to **`internal/`**. **1.1.x+** (Band 4) adds multi-cluster, analyze, triggered collect-on-signal, and addons — only after that contract.
 
@@ -66,6 +66,7 @@ GROOT is a **read-only log and context collector**: one **`groot collect`** prod
 - Not **live log streaming / tail** (`groot stream`) — outside product philosophy (use `kubectl logs -f`, stern, or a log shipper). Continuous value for groot is **triggered collect → archive → upload → notify**, not a log agent.
 - Not **multi-cluster native** until Band 4 `#32`.
 - Not **mutating** cluster operations, full OpenTelemetry agent, managed SaaS, or native Windows GUI (long-term out of scope).
+- Not a long-lived **HTTP server** or **archive catalog** inside this CLI — on-demand collect is **[groot-trigger](https://github.com/hrodrig/groot-trigger)**; VPS door is **[groot-share](https://github.com/hrodrig/groot-share)** (**gfs**), deployed via **[groot-share-selfhosted](https://github.com/hrodrig/groot-share-selfhosted)**.
 
 ### Community signals (Band 4)
 

--- a/SPECIFICATIONS.md
+++ b/SPECIFICATIONS.md
@@ -23,6 +23,8 @@ This document is the source of truth for **observable behavior** and test expect
 
 - Mutating cluster resources (scale, delete, patch, apply).
 - Continuous monitoring or in-cluster controller beyond a **CronJob** schedule (no Operator).
+- Long-lived HTTP inside this CLI (on-demand collect API: **[groot-trigger](https://github.com/hrodrig/groot-trigger)**).
+- Archive catalog / VPS door (**[groot-share](https://github.com/hrodrig/groot-share)** / **gfs**); gfs deploy playbooks live in **[groot-share-selfhosted](https://github.com/hrodrig/groot-share-selfhosted)**.
 - Arbitrary non-JSON webhook bodies.
 - Multi-cluster capture in one archive (see ROADMAP **1.0.0 #32**).
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hrodrig/groot
 
-go 1.26.5
+go 1.26.6
 
 require (
 	cloud.google.com/go/storage v1.62.3

--- a/internal/analyze/render_llm.go
+++ b/internal/analyze/render_llm.go
@@ -229,24 +229,20 @@ func buildLLMView(r Report) llmView {
 		vm.Hints = append(vm.Hints, hv)
 	}
 	for _, n := range r.Notes {
-		vm.Notes = append(vm.Notes, llmNoteView{
-			Code:    n.Code,
-			Message: n.Message,
-			Path:    n.Path,
-		})
+		vm.Notes = append(vm.Notes, llmNoteView(n))
 	}
 	return vm
 }
 
-func clipRunes(s string, max int) string {
-	if max <= 0 || s == "" {
+func clipRunes(s string, maxRunes int) string {
+	if maxRunes <= 0 || s == "" {
 		return ""
 	}
 	r := []rune(s)
-	if len(r) <= max {
+	if len(r) <= maxRunes {
 		return s
 	}
-	return string(r[:max]) + "…"
+	return string(r[:maxRunes]) + "…"
 }
 
 // shrinkLLMView drops lowest-value content. Returns false when nothing left to

--- a/internal/analyze/render_llm_test.go
+++ b/internal/analyze/render_llm_test.go
@@ -253,10 +253,7 @@ func TestRenderLLM_NoArcreadImport(t *testing.T) {
 	if strings.Contains(string(src), "arcread") {
 		t.Fatal("render_llm.go must not import or reference arcread")
 	}
-	if strings.Contains(string(src), "analyze.Run") || strings.Contains(string(src), "\tRun(") {
-		// Soft check: file should not call Run.
-	}
-	// Ensure no call to Run as a bare identifier import pattern — package is analyze itself.
+	// Soft check: file should not call Run / open archives.
 	if strings.Contains(string(src), "Run(") && strings.Contains(string(src), "arcread.Open") {
 		t.Fatal("render_llm.go must remain pure over Report")
 	}

--- a/internal/analyze/scan.go
+++ b/internal/analyze/scan.go
@@ -38,8 +38,5 @@ func scanEventBodies(ev evidence, match func(string) bool) *lineHit {
 	if h := scanLines(ev.warningEvents, ev.warningPath, match); h != nil {
 		return h
 	}
-	if h := scanLines(ev.podsWide, ev.podsWidePath, match); h != nil {
-		return h
-	}
-	return nil
+	return scanLines(ev.podsWide, ev.podsWidePath, match)
 }

--- a/internal/arcread/member.go
+++ b/internal/arcread/member.go
@@ -56,7 +56,7 @@ func (a *Archive) ReadMemberLimit(name string, limit int64) ([]byte, error) {
 			return nil, fmt.Errorf("tar read: %w", err)
 		}
 		switch hdr.Typeflag {
-		case tar.TypeReg, tar.TypeRegA:
+		case tar.TypeReg:
 			ordinal++
 		default:
 			continue

--- a/internal/arcread/safety.go
+++ b/internal/arcread/safety.go
@@ -53,7 +53,7 @@ func normalizeMemberName(name string) (string, error) {
 
 func checkTypeflag(typeflag byte, name string) error {
 	switch typeflag {
-	case tar.TypeReg, tar.TypeRegA, tar.TypeDir:
+	case tar.TypeReg, tar.TypeDir:
 		return nil
 	case tar.TypeSymlink, tar.TypeLink:
 		return fmt.Errorf("%w: %q", ErrUnsupportedType, name)

--- a/internal/cmd/exitcode.go
+++ b/internal/cmd/exitcode.go
@@ -76,7 +76,7 @@ func (e *ExitError) ExitCode() int {
 		return ExitSuccess
 	}
 	if e.Code < 0 || e.Code > 255 {
-		// os.Exit masks to 8 bits; clamp to keep behaviour predictable and
+		// os.Exit masks to 8 bits; clamp to keep behavior predictable and
 		// avoid stderr/logs that lie about the configured code.
 		return ExitSuccess
 	}

--- a/internal/cmd/plugin_extras_test.go
+++ b/internal/cmd/plugin_extras_test.go
@@ -95,7 +95,7 @@ func TestValueOrUnknown(t *testing.T) {
 }
 
 // Ensure file path printing in error messages does not exceed reasonable
-// lengths; this is a behavioural smoke so error formatting regressions don't
+// lengths; this is a behavioral smoke so error formatting regressions don't
 // flood user logs.
 func TestSampleYAMLPath_safeToPrint(t *testing.T) {
 	tmp := filepath.Join(t.TempDir(), "config.yml")

--- a/internal/cmd/plugin_test.go
+++ b/internal/cmd/plugin_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 )
 
@@ -29,13 +28,7 @@ func TestIsPluginInvocation_basenameMatch(t *testing.T) {
 		t.Fatal("/opt/krew/bin/kubectl-groot must be flagged as plugin invocation")
 	}
 
-	// Someone on Windows running `kubectl-groot.exe` directly (after PATH
-	// lookup strips the suffix); we do not strip extensions ourselves but
-	// .exe is the only realistic case on Windows.
-	if filepath.Ext(filepath.Base(os.Args[0])) == ".exe" {
-		// covered separately in TestIsPluginInvocation_windowsExe below;
-		// keep this branch as a no-op so the table stays self-explanatory.
-	}
+	// Windows `.exe` basename covered in TestIsPluginInvocation_windowsExe.
 }
 
 func TestIsPluginInvocation_envOverride(t *testing.T) {

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -709,8 +709,8 @@ func (s *Service) writePodRCATable(captureDir string, podResources map[string]po
 				memReq, memLim = totals.MemoryRequest, totals.MemoryLimit
 			}
 		}
-		b.WriteString(fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			ns, pod, node, cpu, mem, cpuReq, cpuLim, memReq, memLim, logFile))
+		_, _ = fmt.Fprintf(&b, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			ns, pod, node, cpu, mem, cpuReq, cpuLim, memReq, memLim, logFile)
 	}
 
 	target := filepath.Join(captureDir, "extras", "all-pods-rca.tsv")
@@ -735,7 +735,7 @@ func (s *Service) writePodNodePlacement(ctx context.Context, captureDir string) 
 		if p, ok := logPaths[ref.Namespace+"/"+ref.Name]; ok {
 			logRel = p
 		}
-		b.WriteString(fmt.Sprintf("%s\t%s\t%s\t%s\n", ref.Namespace, ref.Name, ref.Node, logRel))
+		_, _ = fmt.Fprintf(&b, "%s\t%s\t%s\t%s\n", ref.Namespace, ref.Name, ref.Node, logRel)
 	}
 
 	target := filepath.Join(captureDir, "extras", "all-pod-node-placement.tsv")

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -953,7 +953,7 @@ func matchesTargetsByLabels(labels map[string]string, targets config.NamespaceTa
 //
 // Helm-canonical labels are app.kubernetes.io/instance + app.kubernetes.io/name,
 // usually paired with app.kubernetes.io/managed-by=Helm. Legacy Helm 2 used
-// heritage=Tiller + chart=NAME. We honour the modern labels first and fall back
+// heritage=Tiller + chart=NAME. We honor the modern labels first and fall back
 // to the legacy pair, while refusing to match non-Helm workloads that happen to
 // carry app.kubernetes.io/instance (e.g. Kustomize, Operators): if a managed-by
 // label is present and identifies a non-Helm owner, the pod is excluded even

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -266,7 +266,7 @@ func TestHelmMatches(t *testing.T) {
 	}
 
 	// Belt-and-braces: matchesTargetsByLabels must use helmMatches when
-	// helm_releases is populated, so the rejection behaviour above flows
+	// helm_releases is populated, so the rejection behavior above flows
 	// through end-to-end. A Kustomize-owned pod with a matching instance must
 	// NOT be considered a Helm target by the umbrella helper.
 	nonHelm := map[string]string{

--- a/internal/collector/run_integration_test.go
+++ b/internal/collector/run_integration_test.go
@@ -372,7 +372,7 @@ func TestService_Run_invalidKubeconfig(t *testing.T) {
 
 func TestService_buildJobs_nodeListFails(t *testing.T) {
 	cs := fake.NewSimpleClientset()
-	cs.Fake.PrependReactor("list", "nodes", func(_ ktesting.Action) (bool, runtime.Object, error) {
+	cs.PrependReactor("list", "nodes", func(_ ktesting.Action) (bool, runtime.Object, error) {
 		return true, &corev1.NodeList{}, fmt.Errorf("simulated node list failure")
 	})
 	svc := New(config.Config{

--- a/internal/collector/unhealthy_test.go
+++ b/internal/collector/unhealthy_test.go
@@ -89,7 +89,7 @@ func TestTally_runningContainersIgnoresOldTerminated(t *testing.T) {
 	}
 	// Container currently with a previous OOMKilled but no Waiting state —
 	// we do not count it as currently OOMKilled; that surfaces via summary
-	// only on restart-loop policies. Document the behaviour here.
+	// only on restart-loop policies. Document the behavior here.
 	_ = mkOOMTerminated // silence unused when no test body relies on the constructor
 	pod := []corev1.Pod{{
 		Status: corev1.PodStatus{

--- a/internal/collector/workload_resources.go
+++ b/internal/collector/workload_resources.go
@@ -164,11 +164,11 @@ func writeWorkloadResourcesTSV(captureDir string, rows []containerResourceRow) e
 		if row.InitContainer {
 			initFlag = "true"
 		}
-		b.WriteString(fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		_, _ = fmt.Fprintf(&b, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			row.Namespace, row.Pod, row.Node, row.Container, initFlag,
 			row.CPURequest, row.CPULimit, row.MemoryRequest, row.MemoryLimit,
 			row.OwnerKind, row.OwnerName,
-		))
+		)
 	}
 	target := filepath.Join(captureDir, "extras", "workload-resources.tsv")
 	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {

--- a/internal/k8srunner/runner_test.go
+++ b/internal/k8srunner/runner_test.go
@@ -319,11 +319,11 @@ func TestRunner_Run_top_with_metrics_fake(t *testing.T) {
 		},
 	}
 	mc := metricsfake.NewSimpleClientset()
-	mc.Fake.PrependReactor("list", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
+	mc.PrependReactor("list", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
 		_ = action
 		return true, &metricsv1beta1api.PodMetricsList{Items: []metricsv1beta1api.PodMetrics{*pm}}, nil
 	})
-	mc.Fake.PrependReactor("get", "nodes", func(action ktesting.Action) (bool, runtime.Object, error) {
+	mc.PrependReactor("get", "nodes", func(action ktesting.Action) (bool, runtime.Object, error) {
 		ga, ok := action.(ktesting.GetAction)
 		if !ok || ga.GetName() != "node1" {
 			return false, nil, nil
@@ -508,7 +508,6 @@ func TestRunner_Run_get_extended(t *testing.T) {
 	ctx := context.Background()
 
 	type seedFn func() runtime.Object
-	type expectFn func(*testing.T, string)
 
 	cases := []struct {
 		name    string

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -161,14 +161,14 @@ func cloneStringMap(in map[string]string) map[string]string {
 
 // discordWebhookContent truncates text to Discord's incoming-webhook "content" limit (2000 characters).
 func discordWebhookContent(text string) string {
-	const max = 2000
+	const maxRunes = 2000
 	r := []rune(text)
-	if len(r) <= max {
+	if len(r) <= maxRunes {
 		return text
 	}
 	const suffix = "..."
 	sr := []rune(suffix)
-	cut := max - len(sr)
+	cut := maxRunes - len(sr)
 	if cut < 0 {
 		cut = 0
 	}

--- a/internal/uploader/s3.go
+++ b/internal/uploader/s3.go
@@ -75,7 +75,9 @@ func (u *s3Uploader) Upload(ctx context.Context, archivePath string, summary col
 	}
 	input.Metadata = mergeMetadata(u.cfg.Metadata, summary.RunID)
 
+	//nolint:staticcheck // SA1019: manager.Uploader still the supported path until transfermanager migration.
 	up := manager.NewUploader(client)
+	//nolint:staticcheck // SA1019: see NewUploader note above.
 	out, err := up.Upload(ctx, input)
 	if err != nil {
 		return nil, fmt.Errorf("put object: %w", err)


### PR DESCRIPTION
## What changed

Operators landing on the product repo can now reach the rest of the groot family: scheduled/bastion deploy, on-demand in-cluster collect, VPS archive catalog (gfs), and gfs deploy playbooks. `make lint` / the CI lint job now run golangci-lint v2 instead of bare `go vet`.

## Why

The hub only linked groot-selfhosted, so trigger and share were easy to miss. Lint needed the same conservative v2 gate as the other CLIs (govet, staticcheck, ineffassign, misspell, revive, unused).

This is a **release merge** (`develop` → `main`). It also carries the GSD STATE sync already on `develop`.

## How to test

- [ ] `make lint-fix` then `make ci` (fmt-check + golangci-lint + gocyclo + tests; or `make all` for coverage too)
- [ ] `make security` (if your change touches deps, Docker, or security-sensitive paths)
- [x] Manual verification: README nav + Groot family table list groot-selfhosted, groot-trigger, groot-share (gfs), and groot-share-selfhosted; Related tools block still the four CLIs

## Checklist

- [x] PR targets **`main`** (release merge from `develop`)
- [x] Scope is focused and documented
- [x] No secrets or credentials committed
- [x] README/docs updated when behavior changed
